### PR TITLE
Some small fixes to dns-tcp-socks-proxy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,7 @@
+FLAGS=-Wall -Wextra
 all:
-	gcc -o dns_proxy dns_proxy.c
+	gcc $(FLAGS) -o dns_proxy dns_proxy.c
+PHONY : clean
+clean :
+	-rm dns_proxy
+

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 FLAGS=-Wall -Wextra
 all:
 	gcc $(FLAGS) -o dns_proxy dns_proxy.c
-PHONY : clean
+.PHONY : clean
 clean :
 	-rm dns_proxy
 

--- a/dns_proxy.c
+++ b/dns_proxy.c
@@ -335,4 +335,5 @@ int main(int argc, char *argv[]) {
 
   // start the dns proxy
   udp_listener();
+  exit(EXIT_SUCCESS);
 }

--- a/dns_proxy.c
+++ b/dns_proxy.c
@@ -69,7 +69,7 @@ char *get_value(char *line) {
 }
 
 char *string_value(char *value) {
-  char *tmp = (char*)malloc(strlen(value));
+  char *tmp = (char*)malloc(strlen(value)+1);
   strcpy(tmp, value);
   value = tmp;
   if (value[strlen(value)-1] == '\n')

--- a/dns_proxy.c
+++ b/dns_proxy.c
@@ -105,6 +105,8 @@ void parse_config(char *file) {
     else if(strstr(line, "log_file") != NULL)
       LOGFILE = string_value(get_value(line));
   }
+  if (fclose(f) != 0)
+	  error("[!] Error closing configuration file");
 }
 
 void parse_resolv_conf() {
@@ -123,8 +125,9 @@ void parse_resolv_conf() {
       NUM_DNS++;
   }
 
-  fclose(f);
-
+  if (fclose(f))
+    error("[!] Error closing resolv.conf");
+  
   dns_servers = malloc(sizeof(char*) * NUM_DNS);
 
   f = fopen(RESOLVCONF, "r");
@@ -135,6 +138,8 @@ void parse_resolv_conf() {
     strcpy(dns_servers[i], ns);
     i++;
   }
+  if (fclose(f))
+    error("[!] Error closing resolv.conf");
 }
 
 // handle children

--- a/dns_proxy.c
+++ b/dns_proxy.c
@@ -80,7 +80,7 @@ char *string_value(char *value) {
 }
 
 void parse_config(char *file) {
-  char line[80], *tmp;
+  char line[80];
 
   FILE *f = fopen(file, "r");
   if (!f)


### PR DESCRIPTION
I found some issues in the dns_proxy software. I think these changes would make it better. Especially  commit 8c03e111a1ed56808dbd1a15ba8c407ca63bad1f to handle negative return values from recvfrom() makes the application behave much better.
